### PR TITLE
Replace forward slashes in the region.

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/dcos/DcosServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/dcos/DcosServerGroupCreator.groovy
@@ -17,6 +17,11 @@ class DcosServerGroupCreator implements ServerGroupCreator {
     def operation = [:]
 
     // TODO: this is side-effecty and not good... but it works.
+    //
+    // Have to do this here because during a deploy stage in a pipeline run, a disconnect between how the region is
+    // sent in from deck (which may contain forward slashes) and how the region is formatted and written by clouddriver
+    // (using underscores) causes the ParallelDeployStage to fail when trying to lookup server groups keyed by region.
+    // The map contains a region with underscores, but the lookup occurs using a region with forward slashes.
     stage.context.region = stage.context.region.replaceAll('/', '_')
 
     // If this stage was synthesized by a parallel deploy stage, the operation properties will be under 'cluster'.

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/dcos/DcosServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/dcos/DcosServerGroupCreator.groovy
@@ -16,6 +16,9 @@ class DcosServerGroupCreator implements ServerGroupCreator {
   List<Map> getOperations(Stage stage) {
     def operation = [:]
 
+    // TODO: this is side-effecty and not good... but it works.
+    stage.context.region = stage.context.region.replaceAll('/', '_')
+
     // If this stage was synthesized by a parallel deploy stage, the operation properties will be under 'cluster'.
     if (stage.context.containsKey("cluster")) {
       operation.putAll(stage.context.cluster as Map)


### PR DESCRIPTION
I really don't like that this actually works. Altering the region in the stage context in this "get" method is probably be an unexpected side effect to whatever is calling this method. Given that, this method is probably pretty brittle.

The Amazon provider has some interesting classes that look like they could be used by us to provide a more robust solution to this problem, but it may be overkill. There is this DeployStagePreProcessor interface that we can implement, which AWS uses [1].

[1] https://github.com/cerner/orca/blob/master/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/AwsDeployStagePreProcessor.groovy